### PR TITLE
added backup switch command 

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ alias cb := cluster-build
 alias ca := cluster-apply
 alias hb := home-build
 alias hs := home-switch
+alias hbs := home-backup-switch
 
 # run a command in the universe shell
 sh +ARGS:
@@ -23,6 +24,9 @@ home-build:
 
 home-switch:
   @just _home-manager switch
+
+home-backup-switch:
+  @just _home-manager-bkp switch
 
 cluster-build:
   @just _c build
@@ -42,6 +46,9 @@ gen-homie-cfg:
 
 _home-manager goal:
   just sh "home-manager -f $MACHINE/home.nix {{goal}}"
+
+_home-manager-bkp goal:
+  just sh "home-manager -b backup -f $MACHINE/home.nix {{goal}}"
 
 _c +ARGS="":
   just sh "colmena -f $CLUSTER_CONFIG {{ARGS}}"


### PR DESCRIPTION
kept having to manually backup the home manager apps dir 


```bash
> just hs
...
cmp: /nix/store/p0vbpn4n8pvypd0ngr1dv48060asjkk1-home-manager-files/Applications/Home Manager Apps: Is a directory
Existing file '/Users/scott/Applications/Home Manager Apps' is in the way of '/nix/store/p0vbpn4n8pvypd0ngr1dv48060asjkk1-home-manager-files/Applications/Home Manager Apps'
Please move the above files and try again or use 'home-manager switch -b backup' to back up existing files automatically.
```

```bash
> just hbs
...
cmp: /nix/store/p0vbpn4n8pvypd0ngr1dv48060asjkk1-home-manager-files/Applications/Home Manager Apps: Is a directory
Existing file '/Users/scott/Applications/Home Manager Apps' is in the way of '/nix/store/p0vbpn4n8pvypd0ngr1dv48060asjkk1-home-manager-files/Applications/Home Manager Apps', will be moved to '/Users/scott/Applications/Home Manager Apps.backup'
```